### PR TITLE
[refactor]Refactor ByteBuf release method in DefaultEntryLogger

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/DefaultEntryLogger.java
@@ -31,6 +31,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.BufferedReader;
 import java.io.File;
@@ -190,7 +191,7 @@ public class DefaultEntryLogger implements EntryLogger {
                     throw e;
                 }
             } finally {
-                serializedMap.release();
+                ReferenceCountUtil.safeRelease(serializedMap);
             }
             // Flush the ledger's map out before we write the header.
             // Otherwise the header might point to something that is not fully
@@ -842,7 +843,7 @@ public class DefaultEntryLogger implements EntryLogger {
         ByteBuf data = allocator.buffer(entrySize, entrySize);
         int rc = readFromLogChannel(entryLogId, fc, data, pos);
         if (rc != entrySize) {
-            data.release();
+            ReferenceCountUtil.safeRelease(data);
             throw new IOException("Bad entry read from log file id: " + entryLogId,
                     new EntryLookupException("Short read for " + ledgerId + "@"
                                               + entryId + " in " + entryLogId + "@"
@@ -876,7 +877,7 @@ public class DefaultEntryLogger implements EntryLogger {
             int ledgersCount = headers.readInt();
             return new Header(headerVersion, ledgersMapOffset, ledgersCount);
         } finally {
-            headers.release();
+            ReferenceCountUtil.safeRelease(headers);
         }
     }
 
@@ -1025,7 +1026,7 @@ public class DefaultEntryLogger implements EntryLogger {
                 pos += entrySize;
             }
         } finally {
-            data.release();
+            ReferenceCountUtil.safeRelease(data);
         }
     }
 
@@ -1117,7 +1118,7 @@ public class DefaultEntryLogger implements EntryLogger {
         } catch (IndexOutOfBoundsException e) {
             throw new IOException(e);
         } finally {
-            ledgersMap.release();
+            ReferenceCountUtil.safeRelease(ledgersMap);
         }
 
         if (meta.getLedgersMap().size() != header.ledgersCount) {


### PR DESCRIPTION
### Motivation
It may throw an exception when release  a `ByteBuf` object.  So the exception in `ByteBuf.release` should be checked.

### Changes
Use `ReferenceCountUtil.safeRelease()` instead of `ByteBuf.release()`.

Master Issue: [#2](https://github.com/HQebupt/bookkeeper/pull/2)
