### PR TITLE
[refactor][bookkeeper] Refactor ByteBuf release method in bookkeeper-common-allocator

### DIFF
--- a/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
+++ b/bookkeeper-common-allocator/src/test/java/org/apache/bookkeeper/common/allocator/impl/ByteBufAllocatorBuilderTest.java
@@ -29,6 +29,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.common.allocator.ByteBufAllocatorBuilder;
@@ -229,17 +230,17 @@ public class ByteBufAllocatorBuilderTest {
         ByteBuf buf1 = alloc.buffer();
         assertEquals(pooledAlloc, buf1.alloc());
         assertFalse(buf1.hasArray());
-        buf1.release();
+        ReferenceCountUtil.safeRelease(buf1);
 
         ByteBuf buf2 = alloc.directBuffer();
         assertEquals(pooledAlloc, buf2.alloc());
         assertFalse(buf2.hasArray());
-        buf2.release();
+        ReferenceCountUtil.safeRelease(buf2);
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertEquals(pooledAlloc, buf3.alloc());
         assertTrue(buf3.hasArray());
-        buf3.release();
+        ReferenceCountUtil.safeRelease(buf3);
     }
 
     @Test
@@ -255,14 +256,14 @@ public class ByteBufAllocatorBuilderTest {
         assertEquals(PooledByteBufAllocator.class, buf1.alloc().getClass());
         assertEquals(3, ((PooledByteBufAllocator) buf1.alloc()).metric().numDirectArenas());
         assertFalse(buf1.hasArray());
-        buf1.release();
+        ReferenceCountUtil.safeRelease(buf1);
 
         ByteBuf buf2 = alloc.directBuffer();
         assertFalse(buf2.hasArray());
-        buf2.release();
+        ReferenceCountUtil.safeRelease(buf2);
 
         ByteBuf buf3 = alloc.heapBuffer();
         assertTrue(buf3.hasArray());
-        buf3.release();
+        ReferenceCountUtil.safeRelease(buf3);
     }
 }


### PR DESCRIPTION
### Motivation
It may throw an exception when release  a `ByteBuf` object.  So the exception in `ByteBuf.release` should be checked.

### Changes
Use `ReferenceCountUtil.safeRelease()` instead of `ByteBuf.release()`.

Master Issue: [#6](https://github.com/HQebupt/bookkeeper/pull/6)
