### PR TITLE
[improve] add read rate limter for compaction

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/conf/ServerConfiguration.java
@@ -105,6 +105,7 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     protected static final String COMPACTION_RATE = "compactionRate";
     protected static final String COMPACTION_RATE_BY_ENTRIES = "compactionRateByEntries";
     protected static final String COMPACTION_RATE_BY_BYTES = "compactionRateByBytes";
+    protected static final String COMPACTION_READ_RATE_BY_BYTES = "compactionReadRateByBytes";
 
     // Gc Parameters
     protected static final String GC_WAIT_TIME = "gcWaitTime";
@@ -2963,6 +2964,27 @@ public class ServerConfiguration extends AbstractConfiguration<ServerConfigurati
     public ServerConfiguration setCompactionRateByBytes(int rate) {
         setProperty(COMPACTION_RATE_BY_BYTES, rate);
         return this;
+    }
+
+    /**
+     * Set the read rate of compaction.
+     *
+     * @param rate read rate of compaction (read bytes per second)
+     *
+     * @return ServerConfiguration
+     */
+    public ServerConfiguration setCompactionReadRateByBytes(int rate) {
+        setProperty(COMPACTION_READ_RATE_BY_BYTES, rate);
+        return this;
+    }
+
+    /**
+     * Get the read rate of compaction. Default is Integer.MAX_VALUE.
+     *
+     * @return read rate of compaction (read bytes per second)
+     */
+    public int getCompactionReadRateByBytes() {
+        return getInt(COMPACTION_READ_RATE_BY_BYTES, Integer.MAX_VALUE);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -1396,6 +1396,7 @@ public abstract class CompactionTest extends BookKeeperClusterTestCase {
         restartBookies(c -> {
             c.setIsThrottleByBytes(true);
             c.setCompactionRateByBytes(ENTRY_SIZE / 1000);
+            c.setCompactionReadRateByBytes(ENTRY_SIZE / 1000);
             c.setMinorCompactionThreshold(0.2f);
             c.setMajorCompactionThreshold(0.5f);
             return c;

--- a/conf/bk_server.conf
+++ b/conf/bk_server.conf
@@ -581,6 +581,9 @@ ledgerDirectories=/tmp/bk-data
 # Set the rate at which compaction will readd entries. The unit is bytes added per second.
 # compactionRateByBytes=1000000
 
+# Set the rate at which compaction will read entries. The unit is bytes read per second.
+# compactionReadRateByBytes=1000000
+
 # Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction,
 # which it will use new entry log files to store compacted entries during compaction; if it is set to false,
 # it will use normal compaction, which it shares same entry log file with normal add operations.

--- a/site3/website/docs/reference/config.md
+++ b/site3/website/docs/reference/config.md
@@ -181,6 +181,7 @@ The table below lists parameters that you can set to configure bookies. All conf
 | isThrottleByBytes | Throttle compaction by bytes or by entries. | false | 
 | compactionRateByEntries | Set the rate at which compaction will read entries. The unit is adds per second. | 1000 | 
 | compactionRateByBytes | Set the rate at which compaction will read entries. The unit is bytes added per second. | 1000000 | 
+| compactionReadRateByBytes | Set the rate at which compaction will read entries. The unit is bytes read per second. | 1000000 |
 | useTransactionalCompaction | Flag to enable/disable transactional compaction. If it is set to true, it will use transactional compaction, which uses<br />new entry log files to store entries after compaction; otherwise, it will use normal compaction, which shares same entry<br />log file with normal add operations.<br /> | false | 
 
 


### PR DESCRIPTION
### Motivation
The purpose of this feature is to provide more flexibility and control over the compaction process in the Bookkeeper server by allowing users to configure the read rate of compaction according to their specific requirements.
It adds support for configuring the read rate of compaction in bytes per second.

In our production environment of Bookkeeper, we have set compactionRateByBytes=30M. However, we have observed that it only limits the write speed to disk and does not limit the read speed from disk. In our environment, the continuous saturation of disk IO for reads in compaction is causing issues with data consumption from the disk.

```
// Set the rate at which compaction will readd entries. The unit is bytes added per second.
 compactionRateByBytes=31457280
```

![image](https://github.com/HQebupt/bookkeeper/assets/4970972/033dc6d3-19d7-4fb7-9c6b-5f13c49686ad)

![image](https://github.com/HQebupt/bookkeeper/assets/4970972/f0b27251-7209-4e4d-8357-dcd0b7804778)


### Changes

- In the `GarbageCollectorThread` class, a new field `compactionReadByteRateLimiter` of type RateLimiter is added to control the read rate of compaction.
- In the `ServerConfiguration` class, a new configuration property `COMPACTION_READ_RATE_BY_BYTES` is defined to specify the read rate of compaction in bytes per second. 

Master Issue: #[8](https://github.com/HQebupt/bookkeeper/pull/8)
